### PR TITLE
change import path from "Sirupsen/logrus" to "sirupsen/logrus"

### DIFF
--- a/lfshook.go
+++ b/lfshook.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // We are logging to file, strip colors to make the output more readable

--- a/lfshook_test.go
+++ b/lfshook_test.go
@@ -2,7 +2,7 @@ package lfshook
 
 import (
 	"bytes"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"io/ioutil"
 	"os"
 	"testing"


### PR DESCRIPTION
The latest logrus package has change path to "sirupsen/logrus", this pull request adjust the change to avoid following compile error:

> main.go:4:2: case-insensitive import collision: "vendor/github.com/Sirupsen/logrus" and "vendor/github.com/sirupsen/logrus"
make: *** [adr] Error 1