### PR TITLE
 Add method for setting default file or writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,86 @@
 # Local Filesystem Hook for Logrus
 
-Sometimes developers like to write directly to a file on the filesystem. This is a hook for [logrus](https://github.com/Sirupsen/logrus) designed to allow users to do just that.  The log levels are dynamic at instantiation of the hook, so it is capable of logging at some or all levels.
+[![GoDoc](https://godoc.org/github.com/rifflock/lfshook?status.svg)](http://godoc.org/github.com/rifflock/lfshook)
+
+Sometimes developers like to write directly to a file on the filesystem. This is a hook for [`logrus`](https://github.com/sirupsen/logrus) which designed to allow users to do that. The log levels are dynamic at instantiation of the hook, so it is capable of logging at some or all levels.
 
 ## Example
 ```go
 import (
-	log "github.com/sirupsen/logrus"
 	"github.com/rifflock/lfshook"
+	"github.com/sirupsen/logrus"
 )
 
-var Log *log.Logger
+var Log *logrus.Logger
 
-func NewLogger( config map[string]interface{} ) *log.Logger {
+func NewLogger() *logrus.Logger {
 	if Log != nil {
 		return Log
 	}
 
-	Log = log.New()
-	Log.SetFormatter(&log.JSONFormatter{})
-	Log.Hooks.Add(lfshook.NewHook(lfshook.PathMap{
-		log.InfoLevel : "/var/log/info.log",
-		log.ErrorLevel : "/var/log/error.log",
-	}))
+	pathMap := lfshook.PathMap{
+		logrus.InfoLevel:  "/var/log/info.log",
+		logrus.ErrorLevel: "/var/log/error.log",
+	}
+
+	Log = logrus.New()
+	Log.Hooks.Add(lfshook.NewHook(
+		pathMap,
+		&logrus.JSONFormatter{},
+	))
+
 	return Log
 }
 ```
 
 ### Formatters
-lfshook will strip colors from any TextFormatter type formatters when writing to local file, because the color codes don't look so great.
+`lfshook` will strip colors from any `TextFormatter` type formatters when writing to local file, because the color codes don't look great in file.
 
 ### Log rotation
 In order to enable automatic log rotation it's possible to provide an io.Writer instead of the path string of a log file.
 In combination with pakages like [go-file-rotatelogs](https://github.com/lestrrat/go-file-rotatelogs) log rotation can easily be achieved.
 
 ```go
-  import "github.com/lestrrat/go-file-rotatelogs"
+package main
 
-  path := "/var/log/go.log"
-  writer := rotatelogs.NewRotateLogs(
-    path + ".%Y%m%d%H%M",
-    rotatelogs.WithLinkName(path),
-    rotatelogs.WithMaxAge(time.Duration(86400) * time.Second),
-    rotatelogs.WithRotationTime(time.Duration(604800) * time.Second),
-  )
+import (
+	"github.com/lestrrat/go-file-rotatelogs"
+	"github.com/rifflock/lfshook"
+	"github.com/sirupsen/logrus"
+)
 
-  log.Hooks.Add(lfshook.NewHook(lfshook.WriterMap{
-    logrus.InfoLevel: writer,
-    logrus.ErrorLevel: writer,
-  }))
+var Log *logrus.Logger
+
+func NewLogger() *logrus.Logger {
+	if Log != nil {
+		return Log
+	}
+
+	path := "/var/log/go.log"
+	writer := rotatelogs.NewRotateLogs(
+		path+".%Y%m%d%H%M",
+		rotatelogs.WithLinkName(path),
+		rotatelogs.WithMaxAge(time.Duration(86400)*time.Second),
+		rotatelogs.WithRotationTime(time.Duration(604800)*time.Second),
+	)
+
+	logrus.Hooks.Add(lfshook.NewHook(
+		lfshook.WriterMap{
+			logrus.InfoLevel:  writer,
+			logrus.ErrorLevel: writer,
+		},
+		&logrus.JSONFormatter,
+	))
+
+	Log = logrus.New()
+	Log.Hooks.Add(lfshook.NewHook(
+		pathMap,
+		&logrus.JSONFormatter{},
+	))
+
+	return Log
+}
 ```
 
 ### Note:
-Whichever user is running the go application must have read/write permissions to the log files selected, or if the files do not yet exists, then to the directory in which the files will be created.
+User who run the go application must have read/write permissions to the selected log files. If the files do not exists yet, then user must have permission to the target directory.

--- a/lfshook.go
+++ b/lfshook.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"reflect"
 	"sync"
 
@@ -133,6 +134,10 @@ func (hook *lfsHook) fileWrite(entry *logrus.Entry) error {
 		log.Println(err.Error())
 		return err
 	}
+
+	dir := filepath.Dir(path)
+	os.MkdirAll(dir, os.ModePerm)
+
 	fd, err = os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0666)
 	if err != nil {
 		log.Println("failed to open logfile:", path, err)


### PR DESCRIPTION
The main focus of this PR is to add new method for setting default output file if there are no output defined for some or all log level. This method is especially useful if you want to put all log level to single file.

```go
package main

import (
	"github.com/RadhiFadlillah/lfshook"
	"github.com/sirupsen/logrus"
)

func main() {
	// Create lfs hook
	hook := lfshook.NewHook(nil, nil)
	hook.SetDefaultPath("general.log")

	// Connect hook with logrus
	logrus.StandardLogger().AddHook(hook)

	// Create some log
	logrus.Infoln("This is info")
	logrus.Warnln("This is warning")
	logrus.Errorln("This is error")
	logrus.Fatalln("This is fatal")
}
```

Code above will make a `general.log` file which contains all logs :

```
time="2017-12-10T22:11:22+07:00" level=info msg="This is info"
time="2017-12-10T22:11:22+07:00" level=warning msg="This is warning"
time="2017-12-10T22:11:22+07:00" level=error msg="This is error"
time="2017-12-10T22:11:22+07:00" level=fatal msg="This is fatal"
```

While adding this method, I fixed some bugs :

1. `lfshook` will fail to create new log file if target directory doesn't exist.
2. The formatter that pased through constructor won't disable color mode in `TextFormatter`, which make log files looks weird.